### PR TITLE
Revert breaking change to race property

### DIFF
--- a/gdcdictionary/schemas/demographic.yaml
+++ b/gdcdictionary/schemas/demographic.yaml
@@ -70,22 +70,18 @@ properties:
   race:
     term:
       $ref: "_terms.yaml#/race"
-    description: >
-      Harmonized race category of participant. Acceptable values: white,american indian or alaska native,black or african american,asian,native hawaiian or other pacific islander,hispanic,multiple,other,Unknown,not reported,not allowed to collect (HARMONIZED)
-    type: array
-    items:
-      enum:
-        - "white"
-        - "american indian or alaska native"
-        - "black or african american"
-        - "asian"
-        - "native hawaiian or other pacific islander"
-        - "hispanic"
-        - "multiple"
-        - "other"
-        - "Unknown"
-        - "not reported"
-        - "not allowed to collect"
+    enum:
+      - "white"
+      - "american indian or alaska native"
+      - "black or african american"
+      - "asian"
+      - "native hawaiian or other pacific islander"
+      - "hispanic"
+      - "multiple"
+      - "other"
+      - "Unknown"
+      - "not reported"
+      - "not allowed to collect"
 
   ethnicity:
     term:


### PR DESCRIPTION
Reverts breaking change made to `race` property in 4.0.12.
*Versions 4.0.12 -> 4.1.x all have this breaking change and will break BDC PFB exports if deployed.*