### PR TITLE
Workaround: add "asian, white" as an enum

### DIFF
--- a/gdcdictionary/schemas/demographic.yaml
+++ b/gdcdictionary/schemas/demographic.yaml
@@ -75,6 +75,7 @@ properties:
       - "american indian or alaska native"
       - "black or african american"
       - "asian"
+      - "asian, white"
       - "native hawaiian or other pacific islander"
       - "hispanic"
       - "multiple"


### PR DESCRIPTION
- This is a workaround for the fact that the Activ4a data has subjects with multiple values in the `race` property. We need to change the property to an array, but as that's a breaking change we'll need to resubmit all the data in sheepdog when we do that, so we need to plan ahead.

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
