### PR TITLE
Added DESC as an option in reference_file data_format

### DIFF
--- a/gdcdictionary/schemas/reference_file.yaml
+++ b/gdcdictionary/schemas/reference_file.yaml
@@ -37,7 +37,7 @@ links:
         target_type: project
         multiplicity: many_to_one
         required: false
-        
+
 required:
   - type
   - submitter_id
@@ -64,7 +64,7 @@ properties:
       - Clinical Data
       - Familial Reference
       - Sequencing Reference
-      - Variant Calling Reference 
+      - Variant Calling Reference
       - Other
 
   data_type:
@@ -72,7 +72,7 @@ properties:
       $ref: "_terms.yaml#/data_type"
     enum:
       - Kinship Matrix
-      - Principal Component      
+      - Principal Component
       - Script
       - Sequencing Reference
       - Unharmonized Clinical Data
@@ -96,10 +96,11 @@ properties:
       - CSV
       - CTR
       - DAT
-      - DTA
       - DB
+      - DESC
       - DOC
       - DOCX
+      - DTA
       - FAI
       - FASTA
       - FMT
@@ -131,19 +132,19 @@ properties:
       - XLSX
       - XML
       - ZIP
-      
-    
+
+
   study_version:
     description: >
       The version of the study that was released by data source (e.g., dbGaP)
     type: number
-    
+
   source_file:
     description: >
       The originating compressed file's name.
     type: string
-    
-    
+
+
   core_metadata_collections:
     $ref: "_definitions.yaml#/to_many"
   projects:


### PR DESCRIPTION
Jira Ticket: [PXP-10744](https://ctds-planx.atlassian.net/browse/PXP-10744)
<PXP-10744>
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features
This change adds `DESC` as an enumeration to the `data_format` property in the `reference_file` node YAML. It also cleans up the alphabetical list of the options in the `data_format` property.

### Breaking Changes
N/A

### Bug Fixes
N/A

### Improvements
Users will now be able to include `DESC` as an option for data_format.

### Dependency updates
N/A

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
